### PR TITLE
Fix issue with third storage tab from the base tabs randomly losing items

### DIFF
--- a/MoreBankTabs/Plugin.cs
+++ b/MoreBankTabs/Plugin.cs
@@ -329,7 +329,7 @@ namespace MoreBankTabs
             [HarmonyPrefix]
             private static bool Init_PutItemIntoStoragePostfix(ItemListDataEntry __instance, int _setItemSlot)
             {
-                if (ItemStorageManager._current._selectedStorageTab >= 2)
+                if (ItemStorageManager._current._selectedStorageTab > 2)
                 {
                     if (__instance._entryType != 0)
                     {


### PR DESCRIPTION
The comparison is erroneous and also grabbed the slot with index 2 (i.e. the third tab). This causes weird behaviours where items were being lost from that slot.

> I've checked, as long a nothing is moved they stay, but when I add soemthign new it disappears upon closing the bank