### PR TITLE
Fix support for extra save files and fix "All" dyeing

### DIFF
--- a/DyeCommands/DyeCommands.csproj
+++ b/DyeCommands/DyeCommands.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>DyeCommands</AssemblyName>
     <Product>DyeCommands</Product>
-    <Version>0.1.0</Version>
+    <Version>0.3.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/DyeCommands/MyPluginInfo.cs
+++ b/DyeCommands/MyPluginInfo.cs
@@ -4,6 +4,6 @@ namespace DyeCommands
     {
         public const string PLUGIN_GUID = "com.16mb.dyecommands";
         public const string PLUGIN_NAME = "DyeCommands";
-        public const string PLUGIN_VERSION = "0.2.0";
+        public const string PLUGIN_VERSION = "0.3.0";
     }
 }


### PR DESCRIPTION
Fixes two things:
- Mod doesn't account for extra save files when trying to save settings for dyes (mainly caused by https://thunderstore.io/c/atlyss/p/Marioalexsan/ExtraSaveSlots/)
- `/dye all someColor` can't be used with "all" due to the string being capitalized as "All" in the switch expression, thus never being matched

I've upped the version for the mod to 0.3.0 in the process, although this would also need to be updated in `manifest.json` if you plan on updating the Thunderstore version.